### PR TITLE
Build support for 32-bit armv8-a

### DIFF
--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -29,6 +29,26 @@
 # include defines, and compiler settings for the given architecture
 # version.
 #
+ifeq ($(strip $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT)),)
+TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT := generic
+endif
+
+KNOWN_ARMv8_CORES := cortex-a53 cortex-a53.a57 cortex-a73
+KNOWN_ARMv8_CORES += kryo denver64 exynos-m1 exynos-m2
+
+# Many devices (incorrectly) use armv7-a-neon as the 2nd architecture variant
+# for cores that implement armv8-a ISAs. The following sets it to armv8-a.
+ifneq (,$(filter $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT), $(KNOWN_ARMv8_CORES)))
+  ifneq ($(TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT),armv8-a)
+    $(warning $(TARGET_$(combo_2nd_arch_prefix)CPU_VARIANT) is armv8-a.)
+    ifneq (,$(TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT))
+      $(warning TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT, $(TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT), ignored! Use armv8-a instead.)
+    endif
+    # Overwrite TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT
+    TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT := armv8-a
+  endif
+endif
+
 ifeq ($(strip $(TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT)),)
 TARGET_$(combo_2nd_arch_prefix)ARCH_VARIANT := armv5te
 endif

--- a/core/combo/arch/arm/armv8-a.mk
+++ b/core/combo/arch/arm/armv8-a.mk
@@ -1,0 +1,9 @@
+# Configuration for Linux on ARM.
+# Generating binaries for the ARMv8-a architecture
+#
+# Many libraries are not aware of armv8-a, and AArch32 is (almost) a superset
+# of armv7-a-neon. So just let them think we are just like v7.
+ARCH_ARM_HAVE_ARMV7A            := true
+ARCH_ARM_HAVE_VFP               := true
+ARCH_ARM_HAVE_VFP_D32           := true
+ARCH_ARM_HAVE_NEON              := true

--- a/target/board/generic_arm64/BoardConfig.mk
+++ b/target/board/generic_arm64/BoardConfig.mk
@@ -35,11 +35,11 @@ ifneq ($(TARGET_BUILD_APPS)$(filter cts,$(MAKECMDGOALS)),)
 # platforms.
 #
 # If you're building a 64 bit platform (and not an application) the
-# ARM-v8 specification allows you to assume NEON and all the features
-# available in a cortex-A15 CPU. You should be able to set :
+# ARM-v8 specification allows you to assume all the features available in an
+# armv7-a-neon CPU. You should set the following as 2nd arch/cpu variant:
 #
-# TARGET_2ND_ARCH_VARIANT := armv7-a-neon
-# TARGET_2ND_CPU_VARIANT := cortex-a15
+# TARGET_2ND_ARCH_VARIANT := armv8-a
+# TARGET_2ND_CPU_VARIANT := generic
 #
 # DO NOT USE
 # DO NOT USE
@@ -50,8 +50,8 @@ TARGET_2ND_CPU_VARIANT := generic
 # DO NOT USE
 # DO NOT USE
 else
-TARGET_2ND_ARCH_VARIANT := armv7-a-neon
-TARGET_2ND_CPU_VARIANT := cortex-a15
+TARGET_2ND_ARCH_VARIANT := armv8-a
+TARGET_2ND_CPU_VARIANT := generic
 endif
 
 


### PR DESCRIPTION
Overwrite TARGET_(2ND_)ARCH_VARIANT as armv8-a if
TARGET_(2ND_)CPU_VARIANT is set to some known armv8-a core like
cortex-a53, cortex-a73, kryo, denver64 etc.

For clang, -march is ignored if -mcpu is set to specific core so this
change doen't impact the objects built for armv7-a-neon/some_armv8_core
since it's treated as armv8-a/some_armv8_core.

Bug: 62895439
Test: Built modified aosp_arm64 with armv8-a as its TARGET_2ND_CPU_ARCH
      and generic as its TARGET_2ND_CPU_VARIANT successfully.
      "lunch hikey-userdebug; make" and verify TARGET_2ND_ARCH_VARIANT
      is overwritten.

Change-Id: If4260cf397783b5f56c4fd432615f4676429a1d3